### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "urls": [
+    ["ina226.py", "github:elschopi/TI_INA226_micropython/ina226.py"],
+    ["ina_calc_conf.py", "github:elschopi/TI_INA226_micropython/ina_calc_conf.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
This PR adds a package.json file to make the library compatible with the MicroPython Package Manager (MIP).

With this change, users can install the library using:
\\\

This will install the INA226 current/power monitor driver modules.